### PR TITLE
Replace mockapi with auth-json-server

### DIFF
--- a/authentication.js
+++ b/authentication.js
@@ -6,7 +6,7 @@ const testAuth = (z /*, bundle*/) => {
   // This method can return any truthy value to indicate the credentials are valid.
   // Raise an error to show
   return z.request({
-      url: 'http://57b20fb546b57d1100a3c405.mockapi.io/api/recipes',
+      url: 'https://auth-json-server.zapier.ninja/me',
     }).then((response) => {
       if (response.status === 401) {
         throw new Error('The API Key you supplied is invalid');

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,14 +11,14 @@ describe('custom auth app', () => {
     // Try changing the values of username or password to see how the test method behaves
     const bundle = {
       authData: {
-        apiKey: 'my_key'
+        apiKey: 'secret'
       }
     };
 
     appTester(App.authentication.test, bundle)
       .then((response) => {
         response.status.should.eql(200);
-        response.request.url.should.containEql('?api_key=my_key');
+        response.request.url.should.containEql('?api_key=secret');
         done();
       })
       .catch(done);


### PR DESCRIPTION
We've set up https://auth-json-server.zapier.ninja, providing all kinds of fake endpoints and authentications for testing. Let's use it for our example apps.